### PR TITLE
Update files for pylint and fallback uuid ozone/aerosol

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(name='swfo',
       install_requires=[
           'click',
           'GDAL',
+          'netCDF4',
           'h5py',
           'numpy',
           'pandas',

--- a/swfo/atsr2_aot.py
+++ b/swfo/atsr2_aot.py
@@ -6,10 +6,10 @@ containing Aerosol Optical Thickness data.
 """
 
 from datetime import datetime as dt
-import glob
-from os.path import join as pjoin, splitext, basename
+from pathlib import Path
 
 from posixpath import join as ppjoin
+
 import numpy
 import h5py
 import pandas
@@ -17,26 +17,32 @@ from shapely.geometry import Polygon
 from shapely import wkt
 from wagl.hdf5 import write_dataframe
 
+from .h5utils import (
+    generate_fallback_uuid, generate_md5sum
+)
 
-def read_pix(filename):
+
+PRODUCT_HREF = 'https://collections.dea.ga.gov.au/ga_c_c_aerosol_2'
+
+
+def read_pix(filename: Path):
     """
     The pix files are sparse 3D arrays.
     Will store as a Table and remove invalid data.
     """
-    src = open(filename, 'rb')
-    recs = numpy.fromfile(src, dtype='int32', count=3)
-    xgrid = numpy.fromfile(src, dtype='float32', count=recs[0])
-    ygrid = numpy.fromfile(src, dtype='float32', count=recs[1])
-    idxlon = numpy.fromfile(src, dtype='int16', count=recs[2])
-    idxlat = numpy.fromfile(src, dtype='int16', count=recs[2])
-    date = numpy.fromfile(src, dtype='int16',
-                          count=recs[2] * 3).reshape(3, recs[2])
-    time = numpy.fromfile(src, dtype='int16',
-                          count=recs[2] * 3).reshape(3, recs[2])
-    lat = numpy.fromfile(src, dtype='float32', count=recs[2])
-    lon = numpy.fromfile(src, dtype='float32', count=recs[2])
-    aot = numpy.fromfile(src, dtype='float32', count=recs[2])
-    src.close()
+    with filename.open('rb') as src:
+        recs = numpy.fromfile(src, dtype='int32', count=3)
+        xgrid = numpy.fromfile(src, dtype='float32', count=recs[0])
+        ygrid = numpy.fromfile(src, dtype='float32', count=recs[1])
+        idxlon = numpy.fromfile(src, dtype='int16', count=recs[2])
+        idxlat = numpy.fromfile(src, dtype='int16', count=recs[2])
+        date = numpy.fromfile(src, dtype='int16',
+                              count=recs[2] * 3).reshape(3, recs[2])
+        time = numpy.fromfile(src, dtype='int16',
+                              count=recs[2] * 3).reshape(3, recs[2])
+        # lat = numpy.fromfile(src, dtype='float32', count=recs[2])
+        # lon = numpy.fromfile(src, dtype='float32', count=recs[2])
+        aot = numpy.fromfile(src, dtype='float32', count=recs[2])
 
     obs_lon = xgrid[idxlon]
     obs_lat = ygrid[idxlat]
@@ -71,12 +77,12 @@ def read_cmp(filename):
     not constant (according to the lon and lat arrays.
     Will store as a Table and remove invalid data.
     """
-    src = open(filename, 'rb')
-    nx = numpy.fromfile(src, dtype='int32', count=1)[0]
-    ny = numpy.fromfile(src, dtype='int32', count=1)[0]
-    lon = numpy.fromfile(src, dtype='float32', count=nx)
-    lat = numpy.fromfile(src, dtype='float32', count=ny)
-    aot = numpy.fromfile(src, dtype='float32', count=nx*ny)
+    with filename.open('rb') as src:
+        nx = numpy.fromfile(src, dtype='int32', count=1)[0]
+        ny = numpy.fromfile(src, dtype='int32', count=1)[0]
+        lon = numpy.fromfile(src, dtype='float32', count=nx)
+        lat = numpy.fromfile(src, dtype='float32', count=ny)
+        aot = numpy.fromfile(src, dtype='float32', count=nx*ny)
 
     obs_lon = []
     obs_lat = []
@@ -109,23 +115,38 @@ def convert(aerosol_path, output_filename, compression, filter_opts):
     """
     # define a case switch
     func = {'pix': read_pix, 'cmp': read_cmp}
+    dataset_names = []
+    metadata = []
 
     # create the output file
-    with h5py.File(output_filename, 'w') as fid:
+    with h5py.File(str(output_filename), 'w') as fid:
 
         pattern = ['*.pix', '*.cmp']
         for p in pattern:
-            search = pjoin(aerosol_path, p)
-            files = glob.glob(search)
-            for fname in files:
-                pth, ext = splitext(fname)
-                ext = ext.split(".")[-1]
-                grp_name = basename(pth)
-                out_path = ppjoin(ext, grp_name)
+            for search_path in aerosol_path.glob(p):
+                _path = search_path.resolve()
+                fname, ext = _path.stem, _path.suffix[1:]  # exclude the period from ext
+                out_path = ppjoin(ext, fname)
+                df, extents = func[ext](_path)
 
                 # read/write
-                df, extents = func[ext](fname)
+                df, extents = func[ext](_path)
+
+                # src checksum; used to help derive fallback uuid
+                with _path.open('rb') as src:
+                    src_checksum = generate_md5sum(src).hexdigest()
+
                 attrs = {'extents': wkt.dumps(extents),
-                         'source filename': fname}
+                         'source filename': str(_path)}
                 write_dataframe(df, out_path, fid, compression=compression,
                                 attrs=attrs, filter_opts=filter_opts)
+                dataset_names.append(out_path)
+                metadata.append({
+                    'id': str(generate_fallback_uuid(
+                        PRODUCT_HREF,
+                        path=str(_path.stem),
+                        md5=src_checksum)
+                             )
+                })
+
+    return metadata, dataset_names


### PR DESCRIPTION
Fallback uuid for aerosol and ozone datasets are generated from a hardcoded namespace derived deterministically from the file name (stem) and a md5 checksum
Other enhancements is some cleanup for reducing pylint noise.