### PR TITLE
Refactor dsm commands; restructure metadata; further tests

### DIFF
--- a/swfo/atsr2_aot.py
+++ b/swfo/atsr2_aot.py
@@ -11,10 +11,11 @@ from pathlib import Path
 from posixpath import join as ppjoin
 
 import numpy
-import h5py
 import pandas
 from shapely.geometry import Polygon
 from shapely import wkt
+import h5py
+
 from wagl.hdf5 import write_dataframe
 
 from .h5utils import (

--- a/swfo/convert.py
+++ b/swfo/convert.py
@@ -478,7 +478,7 @@ def jaxa_tiles(indir, outdir, compression, filter_opts):
 @jaxa_dsm_cli.command('h5-md', help='Convert a JAXA DSM .tar.gz file into a HDF5 file with metadata.')
 @_io_dir_options
 @_compression_options
-def jaxa_tiles(indir, outdir, compression, filter_opts):
+def jaxa_tiles_md(indir, outdir, compression, filter_opts):
     """
     Convert JAXA tar.gz files into a HDF5 files with metadata.
     """

--- a/swfo/ecmwf.py
+++ b/swfo/ecmwf.py
@@ -8,8 +8,8 @@ Conversion utilities for converting ECMWF
 from datetime import datetime
 from pathlib import Path
 import rasterio
-import h5py
 import pandas
+import h5py
 
 from wagl.hdf5.compression import H5CompressionFilter
 from wagl.hdf5 import attach_image_attributes

--- a/swfo/h5utils.py
+++ b/swfo/h5utils.py
@@ -2,11 +2,20 @@
 Utility functions used in the conversion process to hdf5 archives
 """
 
+<<<<<<< dae8d14f23e7a38cd858458132d734f5015efba7
 from typing import Optional, List, Dict, Union
 from io import BufferedReader
+=======
+from typing import Optional, List, Dict
+from io import StringIO, BufferedReader
+import os
+>>>>>>> Enable append-only-like datasets with atomic-write-like behaviour
 import uuid
 import urllib.parse
 import hashlib
+from pathlib import Path
+import tempfile
+from contextlib import contextmanager
 
 from ruamel.yaml import YAML as _YAML
 from ruamel.yaml.compat import StringIO
@@ -14,8 +23,8 @@ import h5py
 
 
 FALLBACK_UUID_NAMESPACE = uuid.UUID('c5908e58-7301-4054-9f04-a0fa8cdef63b')
-PUBLIC_NAMESPACE = '/METADATA'
-PRIVATE_NAMESPACE = '/.METADATA'
+PUBLIC_NAMESPACE = 'METADATA'
+PRIVATE_NAMESPACE = '.METADATA'
 METADATA_PTR = 'CURRENT'
 METADATA_LIST_PTR = 'CURRENT-LIST'
 
@@ -25,7 +34,15 @@ VLEN_STRING = h5py.special_dtype(vlen=str)
 
 def _get_next_md_id(h5_group: h5py.Group, group_prefix: str) -> int:
     """
-    Returns the next incremental ID for metadata versioning
+    Incrementer used to name internal metadata document references
+
+    :param h5_group:
+        h5File root Group
+    :param group_prefix:
+        group_prefix for the metadata documents
+
+    :return:
+        next numeric id to use as a document name
     """
     ids = [0]
 
@@ -42,14 +59,24 @@ def _get_next_md_id(h5_group: h5py.Group, group_prefix: str) -> int:
 def _write_dataset(
         h5_group: h5py.Group,
         dataset: Dict,
-        dataset_path: str = '/',
+        dataset_path: str = '',
         track_order: bool = True) -> h5py.Dataset:
     """
-    Internal function for writing dataset metadata to a H5 file
+    Internal function for writing dataset metadata to a H5file
+
+    :param h5_group:
+        Root reference for the h5 collection
+    :param dataset:
+        metadata encoded as a nested dictionary
+    :param dataset_path:
+        dataset path corresponding to the metadata
+    :param track_order:
+        flag to track insertion order on h5Groups
     """
+    dataset_path = dataset_path.lstrip('/')
     doc_group = '/'.join((PRIVATE_NAMESPACE, dataset_path))
     if not h5_group.get(doc_group):
-        h5_group.create_group(doc_group, track_order=track_order)
+        _create_groups(h5_group, doc_group, track_order=track_order)
 
     doc_id = str(_get_next_md_id(h5_group, doc_group))
     ds = h5_group.create_dataset(
@@ -58,9 +85,9 @@ def _write_dataset(
         shape=(1,)
     )
 
-    with StringIO() as _buf:
-        YAML.dump(dataset, _buf)
-        ds[()] = _buf.getvalue()
+    with StringIO() as stream:
+        YAML.dump(dataset, stream)
+        ds[()] = stream.getvalue()
 
     public_group = '/'.join((PUBLIC_NAMESPACE, dataset_path))
     public_path = public_group + '/' + METADATA_PTR
@@ -75,61 +102,139 @@ def _write_dataset(
     return h5_group[public_path]
 
 
+def _create_groups(root: h5py.Group, group_path: str, track_order: bool = True):
+    """
+    Create hdf5.Group chain ensuring that the track order parameter is set at
+    each level if the group is absent
+
+    :param root:
+        root of the h5py collection
+    :param group_path:
+        group path to make parents for
+    :param track_order:
+        determines if the order for the h5py.Groups should be tracked
+    """
+    _parts = Path(group_path).parts
+
+    if root.get(group_path):
+        return  # early exit
+
+    for _idx in range(1, len(_parts)):
+        _path = os.path.join(*_parts[:_idx])
+        if not root.get(os.path.join(*_parts[:_idx])):
+            root.create_group(_path, track_order=track_order)
+
+
+def _append_data_to_existing_file(inh5: h5py.Group, outh5: h5py.Group, track_order: bool = True):
+    """
+    Internal function to handle appending new data to an existing h5File
+
+    :param inh5:
+        Group to read from
+    :param outh5:
+        Group to write to
+    :param track_order:
+        Add insertion order tracking to created groups
+    """
+
+    if track_order:
+        _traversal_step = -1
+    else:
+        _traversal_step = 1
+
+    def _traverse(root: h5py.Group, offset: str):
+        if isinstance(root[offset], h5py.Dataset):
+            yield root[offset].name
+        elif isinstance(root[offset], h5py.Group):
+            for k in list(root[offset].keys())[::_traversal_step]:
+                if isinstance(root[os.path.join(offset, k)], h5py.Dataset):
+                    yield root[os.path.join(offset, k)].name
+                else:
+                    for name in _traverse(root, os.path.join(offset, k)):
+                        yield name
+
+    md_docs = []
+    md_names = []
+    for k in list(inh5.keys())[::_traversal_step]:
+        if k == PUBLIC_NAMESPACE:
+            continue
+        elif k == PRIVATE_NAMESPACE:
+            for _md in _traverse(inh5, k):
+                md_docs.append(YAML.load(inh5[_md][()].item()))
+                md_names.append('/'.join(_md.split('/')[2:-1]))
+        else:
+            for ds_path in _traverse(inh5, k):
+                if track_order:
+                    _create_groups(inh5, ds_path.rsplit('/', 1)[0],
+                                   track_order=track_order)
+                outh5.create_dataset(ds_path, data=inh5[ds_path])
+
+    write_h5_md(outh5, md_docs, md_names)
+
+
 def write_h5_md(
         h5_group: h5py.Group,
-        datasets: Union[List[Dict], Dict],
-        dataset_names: Optional[List[str]] = None
+        datasets: List[Dict],
+        dataset_names: Optional[List[str]] = None,
+        track_order=True
         ) -> None:
     """
-    Appends metadata documents to a hdf5 collection.
-    Variable length strings will be written to records in
-        /.METADATA/path/to/dataset_name/offset
-    A softlink will be created at:
-        /METADATA/path/to/dataset_name/CURRENT
-    An array of CURRENT metadata docs will be available at:
-        /METADATA/CURRENT-LIST
+    Appends metadata documents to a h5File collection, updating
+    SoftLinks in the public namespace and the metadata listing in the
+    public namespace.
+
+    :param h5_group:
+        reference to the root h5py.Group to write to
+    :param datasets:
+        An array of metadata documents encoded as dictionaries
+    :param dataset_names:
+        An array of dataset names corresponding to each of the documents;
+        for a single dataset h5 collection provide '/'
     """
 
     collection_path = '/'.join((PUBLIC_NAMESPACE, METADATA_LIST_PTR))
-    new_metadata_paths = []
-    old_metadata_paths = []
+    known_metadata_refs = []
+    new_metadata_refs = []
 
     if h5_group.get(collection_path):
-        # Collate known metadata references
-        old_collection = h5_group[collection_path]
-        for i in range(old_collection._dcpl.get_virtual_count()):
-            old_metadata_paths.append(old_collection._dcpl.get_virtual_dsetname(i))
+        # Collate known metadata references; requires access the h5py internal methods
+        existing_refs = h5_group[collection_path]
+        for i in range(existing_refs._dcpl.get_virtual_count()):  # pylint: disable=protected-access
+            known_metadata_refs.append(existing_refs._dcpl.get_virtual_dsetname(i)) # pylint: disable=protected-access
+        existing_refs = None
 
     # Create metadata and collate new references
     for i, _ in enumerate(datasets):
-        ref = _write_dataset(h5_group, datasets[i], dataset_names[i])
-        if ref not in old_metadata_paths:
-            new_metadata_paths.append(ref)
+        curr_ref = _write_dataset(h5_group, datasets[i], dataset_names[i], track_order=track_order)
+        if curr_ref.name not in known_metadata_refs:
+            new_metadata_refs.append(curr_ref.name)
 
-    if new_metadata_paths:
+    if new_metadata_refs:
         # Extend the virtual layout for new datasets
         virtual_collection = h5py.VirtualLayout(
-            shape=(len(old_metadata_paths) + len(new_metadata_paths),),
+            shape=(len(known_metadata_refs) + len(new_metadata_refs),),
             dtype=VLEN_STRING)
 
         ds_cntr = 0
-        for ds_cntr, _ in enumerate(old_metadata_paths):
+        for ds_cntr, _ in enumerate(known_metadata_refs):
             virtual_collection[ds_cntr] = h5py.VirtualSource(
                 path_or_dataset='.',
-                name=old_metadata_paths[ds_cntr],
+                name=known_metadata_refs[ds_cntr],
                 dtype=VLEN_STRING,
                 shape=(1,))
 
         # Increment counter if a dataset was written
-        ds_cntr = ds_cntr + 1 if ds_cntr else 0
+        if known_metadata_refs:
+            ds_cntr = ds_cntr + 1
 
-        for j, _ in enumerate(new_metadata_paths):
+        for j, _ in enumerate(new_metadata_refs):
             virtual_collection[ds_cntr+j] = h5py.VirtualSource(
                 path_or_dataset='.',
-                name=new_metadata_paths[j].name,
+                name=new_metadata_refs[j],
                 dtype=VLEN_STRING,
                 shape=(1,))
 
+        # Recreate the virtual collection
         if h5_group.get(collection_path):
             del h5_group[collection_path]
 
@@ -140,7 +245,16 @@ def generate_fallback_uuid(
         product_href: str, uuid_namespace: uuid.UUID = FALLBACK_UUID_NAMESPACE,
         **product_params):
     """
-    Generates a fallback UUID from the fallback UUID namespace
+    Generates a fallback UUID from the DEA product_href and fallback UUID namespace
+    :param product_href:
+        href to identify the product the dataset relates to
+    :param uuid_namespace:
+        A namespace used to generate a uuid
+    :param product_params:
+        A dictionary urlencoded and appened to the product_href for deterministic uuids
+
+    :return:
+        UUID for the specified product
     """
     return uuid.uuid5(
         uuid_namespace,
@@ -148,13 +262,64 @@ def generate_fallback_uuid(
     )
 
 
-def generate_md5sum(src: BufferedReader, chunk_size=16384):
-    """
+def generate_md5sum(src: BufferedReader, chunk_size: int = 16384):
+    """ 
     Generate a md5sum for the src component.
     Used to help generate fallback uuids
+    :param src:
+        a buffered reader used to calculate md5sum
+    :param chunk_size:
+        chunk_size to used to calculate md5sum
     """
     md5_hash = hashlib.md5()
     for chunk in iter(lambda: src.read(chunk_size), b''):
         md5_hash.update(chunk)
 
     return md5_hash
+
+
+@contextmanager
+def atomic_h5_write(fname: Path, mode: str = 'a', **kwargs):
+    """
+    Will create a temporary h5File location to validate dataset
+    conversion. After completion it will move the file if write is
+    specified or no file exists; otherwise it will append the new datasets
+    and metadata to the specified location.
+    In the event of an error the temporary location will be deleted
+
+    :param fname:
+        path to final location for the dataset
+    :param mode:
+        mode in which to open the file; one of 'a', 'w'
+    :param kwargs:
+        key word arguments to h5file creation
+
+    """
+    os_fid, tpath = tempfile.mkstemp(
+        dir=fname.parent,
+        prefix='.tmp',
+        suffix='.h5')
+    fp = Path(tpath)
+    preexisting = fname.exists()
+    # Fix, don't break read mode
+    try:
+        with h5py.File(tpath, mode=mode, **kwargs) as h5_ref:
+            yield h5_ref
+
+            if mode == 'a' and preexisting:
+                with h5py.File(fname, mode='a', **kwargs) as _out:
+                    # Append datasets to file and delete temporary file
+                    _append_data_to_existing_file(
+                        h5_ref,
+                        _out,
+                        track_order=kwargs.get('track_order', True)
+                    )
+        if mode == 'w' or (mode == 'a' and not preexisting):
+            fp.rename(fname)
+            fp = None
+        else:
+            fp = None
+    finally:
+        os.close(os_fid)
+        if fp and fp.exists():
+            fp.unlink()

--- a/swfo/h5utils.py
+++ b/swfo/h5utils.py
@@ -155,6 +155,19 @@ def _append_data_to_existing_file(inh5: h5py.Group, outh5: h5py.Group, track_ord
 
     md_docs = []
     md_names = []
+
+    # Confirm new non-metadata datasets are missing in output file
+    for k in list(inh5.keys()):
+        if k == PUBLIC_NAMESPACE or k == PRIVATE_NAMESPACE:
+            continue
+        else:
+            for ds_path in _traverse(inh5, k):
+                if outh5.get(ds_path):
+                    raise RuntimeError(
+                        "Dataset {} already exists in file: {}".format(
+                            ds_path, outh5.filename
+                        )
+                    )
     for k in list(inh5.keys())[::_traversal_step]:
         if k == PUBLIC_NAMESPACE:
             continue

--- a/swfo/mcd43a1.py
+++ b/swfo/mcd43a1.py
@@ -8,9 +8,9 @@ from pathlib import Path
 from subprocess import check_call
 import tempfile
 import rasterio
-import h5py
 import netCDF4
 import numpy
+import h5py
 
 from wagl.hdf5 import write_h5_image, attach_attributes, attach_image_attributes
 from wagl.hdf5.compression import H5CompressionFilter

--- a/swfo/ozone.py
+++ b/swfo/ozone.py
@@ -5,8 +5,8 @@ Utility for converting GA's monthly ozone TIFF's to HDF5.
 """
 
 from pathlib import Path
-import h5py
 import rasterio
+import h5py
 
 from wagl.hdf5 import write_h5_image
 
@@ -16,6 +16,18 @@ from .h5utils import (
 
 
 PRODUCT_HREF = 'https://collections.dea.ga.gov.au/ga_c_c_ozone_1'
+
+
+def _month_sort(ozone_path: Path):
+    """
+    Provides a chronological ordering of signifiers
+    """
+    months = [
+        'jan', 'feb', 'mar', 'apr', 'may', 'jun', 
+        'jul', 'aug', 'sep', 'oct', 'nov', 'dec'
+    ]
+    search = ozone_path.stem.lower()
+    return (months.index(search), None) if search in months else (13, search)
 
 
 def convert(indir, out_h5: h5py.Group, compression, filter_opts):
@@ -35,7 +47,7 @@ def convert(indir, out_h5: h5py.Group, compression, filter_opts):
     else:
         filter_opts = filter_opts.copy()
 
-    for fname in indir.glob('*.tif'):
+    for fname in sorted(indir.glob('*.tif'), key=_month_sort):
         with rasterio.open(str(fname)) as rds:
             # the files have small dimensions, so store as a single chunk
             if 'chunks' not in filter_opts:

--- a/swfo/prwtr.py
+++ b/swfo/prwtr.py
@@ -10,8 +10,8 @@ import json
 import numpy
 import osr
 import rasterio
-import h5py
 import pandas
+import h5py
 
 from wagl.geobox import GriddedGeoBox
 from wagl.hdf5.compression import H5CompressionFilter

--- a/tests/test_h5utils.py
+++ b/tests/test_h5utils.py
@@ -1,104 +1,142 @@
 import h5py
 import numpy as np
-import yaml
+from contextlib import contextmanager
 
 from swfo.h5utils import (
     _get_next_md_id,
-    write_h5_md
+    write_h5_md,
+    PUBLIC_NAMESPACE,
+    PRIVATE_NAMESPACE,
+    METADATA_PTR,
+    METADATA_LIST_PTR,
+    YAML
 )
 
 
+@contextmanager
 def _in_memory_h5(tmp_path):
     """
-    Helper function to setup h5 files
+    Helper function to setup h5 in memory file
     """
-    test_file = h5py.File(
-        name=tmp_path / 'test_file.h5',
-        driver='core',
-        backing_store=False
-        )
-
-    # Create Datasets
-
-    return test_file
+    with h5py.File(
+            name=tmp_path / 'test_file.h5',
+            driver='core',
+            backing_store=False
+            ) as test_file:
+        yield test_file
 
 
 def test_get_next_id(tmp_path):
-    h5file = _in_memory_h5(tmp_path)
+    """
+    * Tests next id resolution for the hdf5 archives
+    """
+    with _in_memory_h5(tmp_path) as h5file:
 
-    # Test first id of empty group
-    first_id = _get_next_md_id(h5file, '/')
-    assert first_id == 1
+        # Test first id of empty group
+        first_id = _get_next_md_id(h5file, '/')
+        assert first_id == 1
 
-    # Test first id of non-existent group
-    first_id = _get_next_md_id(h5file, '/METADATA')
-    assert first_id == 1
+        # Test first id of non-existent group
+        first_id = _get_next_md_id(h5file, PRIVATE_NAMESPACE)
+        assert first_id == 1
 
-    # Test getting next id
-    h5file.create_dataset(
-        name='/METADATA/_1',
-        data=np.empty(shape=(1,))
-    )
+        # Test getting next id
+        h5file.create_dataset(
+            name='/'.join((PRIVATE_NAMESPACE, '1')),
+            data=np.empty(shape=(1,))
+        )
 
-    h5file.visit(print)
-    second_id = _get_next_md_id(h5file, '/METADATA')
-    assert second_id == 2
+        h5file.visit(print)
+        second_id = _get_next_md_id(h5file, PRIVATE_NAMESPACE)
+        assert second_id == 2
 
 
 class TestH5Write:
-    def test_simple_dataset(self, tmp_path):
-        h5file = _in_memory_h5(tmp_path)
-
-        sample_md = {
-            'id': 1,
-            'nested_path': { 'key': 'value' }
-        }
-
-        write_h5_md(h5file, datasets=sample_md)
-
-        read_dataset = h5file.get('/METADATA/_1')
-
-        assert read_dataset is not None
-        doc = yaml.load(read_dataset[()][0])
-        assert doc == sample_md
-        del doc
-        del read_dataset
-
-        read_dataset = h5file.get('/METADATA/CURRENT')
-        assert read_dataset is not None
-        doc = yaml.load(read_dataset[()][0])
-
-        assert doc == sample_md
 
     def test_multi_dataset(self, tmp_path):
-        h5file = _in_memory_h5(tmp_path)
-
+        """
+        Simple tests for writing multiple datasets
+        """
         sample_md = [
             {'id': 2},
             {'id': 3},
-            {'id': 4}
+            {'id': 4, 'nested_path': {'key': 'value'}}
         ]
-
         dataset_names = ['two', 'three', 'FOUR']
 
-        write_h5_md(h5file, datasets=sample_md, dataset_names=dataset_names)
+        with _in_memory_h5(tmp_path) as h5file:
+            write_h5_md(h5file, datasets=sample_md, dataset_names=dataset_names)
+            virtual_collection = h5file['/'.join((PUBLIC_NAMESPACE, METADATA_LIST_PTR))]
 
-        for i in range(len(dataset_names)):
-            path = '/METADATA/{}'.format(dataset_names[i])
+            for i in range(len(dataset_names)):
+                path = '/'.join((PRIVATE_NAMESPACE, dataset_names[i]))
 
-            read_dataset = h5file.get(path + '/_1')
-            assert read_dataset is not None
+                read_dataset = h5file.get(path + '/1')
+                assert read_dataset is not None
 
-            doc = yaml.load(read_dataset[()][0])
+                doc = YAML.load(read_dataset[()][0])
 
-            assert doc == sample_md[i]
+                assert doc == sample_md[i]
 
-            assert read_dataset == h5file.get(path + '/CURRENT')
+                public_ref = '/'.join((PUBLIC_NAMESPACE, dataset_names[i], METADATA_PTR))
+                assert read_dataset == h5file.get(public_ref)
 
-            assert (
-                h5file['/METADATA/CURRENT'].virtual_sources()[i].dset_name
-                    == path + '/CURRENT'
-            )
+                assert (
+                    virtual_collection.virtual_sources()[i].dset_name == public_ref
+                )
 
-            del doc
-            del read_dataset
+                del doc
+                del read_dataset
+
+    def test_dataset_move(self, tmp_path):
+        """
+        * Tests the consistency of internal links when moving the HDF5 file.
+            This test is relevant to the handling of virtual datasets
+        """
+        h5fp = tmp_path / 'test.h5'
+        sample_md = [
+            {'id': 2}
+        ]
+        public_path = '/'.join((PUBLIC_NAMESPACE, METADATA_PTR))
+
+        with h5py.File(h5fp, 'w') as h5file:
+            write_h5_md(h5file, datasets=sample_md, dataset_names=['/'])
+            virtual_collection = h5file['/'.join((PUBLIC_NAMESPACE, METADATA_LIST_PTR))]
+
+            assert virtual_collection.virtual_sources()[0].dset_name == public_path
+            assert sample_md[0] == YAML.load(virtual_collection[()][0])
+
+            del virtual_collection
+
+        h5fp.rename(tmp_path / 'test2.h5')
+        h5fp = tmp_path / 'test2.h5'
+        with h5py.File(h5fp, 'r') as h5file:
+            virtual_collection = h5file['/'.join((PUBLIC_NAMESPACE, METADATA_LIST_PTR))]
+
+            assert virtual_collection.virtual_sources()[0].dset_name == public_path
+            assert sample_md[0] == YAML.load(virtual_collection[()][0])
+
+            del virtual_collection
+
+    def test_append_to_dataset(self, tmp_path):
+        """
+        * Tests appending a third datasets to the collection
+        * Tests updating metadata documents by appending the new version
+            and updating the internal references
+        """
+        datasets = [
+            {'id': 1},
+            {'id': 2},
+            {'id': 3}
+        ]
+        dataset_names = ['one', 'two', 'three']
+        with _in_memory_h5(tmp_path) as h5file:
+            write_h5_md(h5file, datasets=[{'id': 'NA'}] * 2, dataset_names=dataset_names[:2])
+            write_h5_md(h5file, datasets=datasets, dataset_names=dataset_names)
+            virtual_collection = h5file['/'.join((PUBLIC_NAMESPACE, METADATA_LIST_PTR))]
+
+            for idx, dname in enumerate(dataset_names):
+                public_path = '/'.join((PUBLIC_NAMESPACE, dname, METADATA_PTR))
+                assert datasets[idx] == YAML.load(h5file[public_path][()].item())
+                # h5file[h5file[public_path].ref] is deferencing the public path
+                assert h5file[h5file[public_path].ref].name == '/'.join((PRIVATE_NAMESPACE, dname, ['2', '2', '1'][idx]))


### PR DESCRIPTION
TODO
- [x] Add documentation
- [x] Update dsm names

Work completed
- [x] refactored dsm commands to separate the jaxa and srtm dsm functions
- [x] extended the metadata specification to be more consistent between single and multi datasets
- [x] Enabled usage of track_order for ozone
- [x] Updated "hidden" signifier to "."; implemented a private namespace for metadata
- [x] Refactored conversion to write to a temporary directory before moving to expected location
- [x] Patched the convert function on dsm to handle files smaller than 256 in one dimension
- [x] Enabled appending single datasets to an existing collection of datasets (including updating references for the soft links and virtual layout)

To consider
- [x] CURRENT offset with in the METADATA namespace serves no purpose except for enabling single file datasets.